### PR TITLE
Merged changes from unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The following packages are required to build and/or run the simulator.
 
 - Debian : gcc | clang | tcc, make, libx11-dev, libc6-dev, xfonts-base
 
-- Fedora : gcc, make, libx11-dev, libc6-dev, xorg-x11-xfonts-base
+- Fedora : gcc, make, libx11-dev, libc6-dev, xorg-x11-xfonts-base or xorg-x11-xfonts-misc
 
 - Gentoo : gcc, make, libx11-dev, libc6-dev, font-misc-misc
 
@@ -200,8 +200,9 @@ saved in the hidden data file.
 
 ### Exiting
 
-Clicking  on the On/Off switch will turn the simulator on and off,  but  if
-you hold down the off switch down for two seconds the program will exit.
+For  models with a 'sliding' On/Off switch clicking on the switch will turn
+the simulator on or off, but if when switching off you hold down the switch
+down for two seconds the program will exit.
 
 
 ### Debugging

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Emulators  for  the HP 35, HP 80, HP 45, HP 70, HP 21, HP 22, HP25, HP 25C,
 HP 27,  HP 29C,  HP 31E, HP 32E, HP 33E, HP 33C,  HP 34C,  HP 37E,  HP 38C,
-HP 38E, HP 67, HP 10C, HP 11C, HP 12C, HP 15 C, and HP 16C.
+HP 38E, HP 67, HP 10C, HP 11C, HP 12C, HP 15C, and HP 16C.
 
 All written in C using X11.
 
@@ -22,6 +22,14 @@ More [screenshots](./img/#top)
 
 
 ### Latest News
+
+24 Feb 24
+   - By default the application will attempt to use the X11 base fonts. But
+     if these are not available it will try to select an suitable alternate
+     font instead from a predefined list.
+
+     For all the fonts to be rendered as intended users should ensure  that
+     the X11 base fonts are installed (see prerequsites).
 
 16 Feb 24
    - For UNIX based systems the default location used to store the state of

--- a/src/makefile
+++ b/src/makefile
@@ -69,7 +69,7 @@ MODEL	= 21
 PROGRAM	= x11-calc
 SOURCES = x11-calc.c x11-calc-cpu.c x11-calc-display.c x11-calc-segment.c
 SOURCES += x11-calc-button.c x11-calc-switch.c x11-calc-label.c x11-calc-colour.c
-SOURCES += x11-keyboard.c x11-calc-messages.c gcc-wait.c gcc-exists.c
+SOURCES += x11-calc-font.c x11-calc-messages.c x11-keyboard.c gcc-wait.c gcc-exists.c
 FILES	= *.c *.h LICENSE README.md makefile x11-calc-*.md .gitignore .gitattributes
 FILES	+= x11-calc-*.png
 OBJECTS	= $(SOURCES:.c=.o)

--- a/src/x11-calc-button.c
+++ b/src/x11-calc-button.c
@@ -49,7 +49,8 @@
  *                     between rows is increased) - MT
  * 12 Feb 22         - Added a style property, currently used to allow flat
  *                     buttons to be drawn - MT
- * 26 Nov 22         - Added support for the original HP10.
+ * 26 Nov 22         - Added support for the original HP10 - MT
+ * 24 Feb 24         - Do not need to include "x11-font.h" - MT
  *
  * To Do             - Add a new style to handle the type of button used by
  *                     the classic series.
@@ -67,7 +68,6 @@
 #include <X11/Xlib.h>  /* XOpenDisplay(), etc. */
 #include <X11/Xutil.h> /* XSizeHints etc. */
 
-#include "x11-calc-font.h"
 #include "x11-calc-switch.h"
 #include "x11-calc-label.h"
 #include "x11-calc-button.h"

--- a/src/x11-calc-cpu.c
+++ b/src/x11-calc-cpu.c
@@ -381,6 +381,7 @@
  *                   - Fixed get_datafile_path() - again. Hopefully it will
  *                     work properly now - MT
  * 19 Feb 24         - Closes ROM file after reading - MT
+ * 23 Feb 24         - Fixed bug in read_rom() - MT
  *
  * To Do             - Finish adding code to display any modified registers
  *                     to every instruction.
@@ -390,8 +391,8 @@
  */
 
 #define NAME           "x11-calc-cpu"
-#define BUILD          "0166"
-#define DATE           "17 Feb 24"
+#define BUILD          "0168"
+#define DATE           "23 Feb 24"
 #define AUTHOR         "MT"
 
 #include <string.h>
@@ -685,7 +686,9 @@ void v_read_rom(oprocessor *h_processor, char *s_pathname) /* Load rom from 'obj
             while (((c_char = fgetc(h_file)) != '\n') && (!feof(h_file)));
          else
          {
-            if (i_count < i_addr) i_count = i_addr - 1;
+            while ((i_count < i_addr) && (i_count < ROM_SIZE))
+               /** i_rom[i_count++] = 0; */
+               i_count++; /* Don't clear ROM */
             if (i_count < ROM_SIZE) i_rom[i_count++] = i_opcode;
          }
       }
@@ -2004,7 +2007,7 @@ void v_processor_tick(oprocessor *h_processor) /* Decode and execute a single in
                   h_processor->reg[C_REG]->nibble[0] = 0;
                   h_processor->code = 0; /* Clear the key code (so it isn't read twice if the key is held down) */
                }
-#endif
+#else
                else
                {
                   h_processor->addr &= 0xfff0;
@@ -2018,6 +2021,7 @@ void v_processor_tick(oprocessor *h_processor) /* Decode and execute a single in
                      v_error(h_err_invalid_address, h_processor->addr, (i_last >> 12), (i_last & 0xfff), __FILE__, __LINE__);
                   }
                }
+#endif
                if (h_processor->trace)
                   v_fprint_register(stdout,h_processor->reg[C_REG]);
                break;

--- a/src/x11-calc-cpu.c
+++ b/src/x11-calc-cpu.c
@@ -403,7 +403,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 
-#include "x11-calc-font.h"
+/** #include "x11-calc-font.h" /* Delete */
 #include "x11-calc-label.h"
 #include "x11-calc-switch.h"
 #include "x11-calc-button.h"

--- a/src/x11-calc-font.c
+++ b/src/x11-calc-font.c
@@ -1,0 +1,63 @@
+/*
+ * x11-calc-font.c - RPN (Reverse Polish) calculator simulator.
+ *
+ * Copyright(C) 2013   MT
+ *
+ * Font definations and data structures.
+ *
+ * This  program is free software: you can redistribute it and/or modify  it
+ * under  the  terms of the GNU General Public License as published  by  the
+ * Free  Software  Foundation, either version 3 of the License, or (at  your
+ * option) any later version.
+ *
+ * This  program  is  distributed in the hope that it will  be  useful,  but
+ * WITHOUT   ANY   WARRANTY;   without  even   the   implied   warranty   of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You  should have received a copy of the GNU General Public License  along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ * 24 Feb 24         - Initial version - MT
+ *                   - Defined an array of alternative fonts for each style
+ *                     of  text required and select the most suitable fonts
+ *                     from these alternatives to reduce the dependancy  on
+ *                     a single set of fonts - MT
+ *
+ */
+
+#define NAME           "x11-calc-button"
+#define BUILD          "0016"
+#define DATE           "26 Nov 22"
+#define AUTHOR         "MT"
+
+#include <stdio.h>
+#include <X11/Xlib.h>
+
+#include "gcc-debug.h"
+
+const char* s_normal_fonts[]    = {"6x12", "*helvetica-medium-r-*-10-*", "-*-courier-medium-r-*-*-11-*-*-*-*-*-*-*", NULL};
+const char* s_small_fonts[]     = {"6x10", "*helvetica-medium-r-*-8-*" , "-*-courier-medium-r-*-*-11-*-*-*-*-*-*-*", NULL};
+const char* s_alternate_fonts[] = {"5x8" , "*helvetica-medium-r-*-8-*" , "-*-courier-medium-r-*-*-11-*-*-*-*-*-*-*", NULL};
+const char* s_large_fonts[]     = {"6x13", "*helvetica-medium-r-*-12-*", "-*-courier-medium-r-*-*-14-*-*-*-*-*-*-*", NULL};
+
+XFontStruct *h_get_font(Display *x_display, const char** s_fonts)
+/*
+ * The get_font() function returns the first available font from a list  of
+ * possible alternative font names.  If none of the fonts exist, it returns
+ * NULL.
+ *
+ */
+{
+   XFontStruct* h_font;
+   int i_count;
+
+   for (i_count = 0; s_fonts[i_count] != NULL; i_count++)
+   {
+      debug(printf("Attempting to load font '%s'\n", s_fonts[i_count]));
+      if ((h_font = XLoadQueryFont(x_display, s_fonts[i_count]))) break;
+      h_font = NULL;
+   }
+   return(h_font);
+}

--- a/src/x11-calc-font.h
+++ b/src/x11-calc-font.h
@@ -21,28 +21,25 @@
  *
  * 09 Mar 14         - Initial version - MT
  * 10 Dec 18         - Defined DEC fonts if compiling on VMS - MT
+ * 24 Feb 24         - Defined an array of alternative fonts for each style
+ *                     of text required - MT
+ * 24 Feb 24         - Moved font definations to "x11-calc-fonts.c" - MT
+ *                   - Defined an array of alternative fonts for each style
+ *                     of  text required and select the most suitable fonts
+ *                     from these alternatives to reduce the dependancy  on
+ *                     a single set of fonts - MT
+ *
  *
  */
-
-#if defined(vms)
-
-#define NORMAL_TEXT    "*helvetica-medium-r-*-10-*" /* 12 Font to use for function keys. */
-#define SMALL_TEXT     "*helvetica-medium-r-*-8-*" /* 10 Font to use for shifted functions. */
-#define LARGE_TEXT     "*helvetica-medium-r-*-12-*" /* 13 Font to use for numeric keys. */
-#define ALTERNATE_TEXT "*helvetica-medium-r-*-8-*"  /*  8 Font to use for alternate functions. */
-
-#else
-
-#define NORMAL_TEXT    "6x12" /* Font to use for function keys. */
-#define SMALL_TEXT     "6x10" /* Font to use for shifted functions. */
-#define LARGE_TEXT     "6x13" /* Font to use for numeric keys. */
-#define ALTERNATE_TEXT "5x8" /* Font to use for alternate functions. */
-
-#endif
 
 XFontStruct *h_normal_font; /* Font for function keys. */
 XFontStruct *h_small_font; /* Font for shifted function labels. */
 XFontStruct *h_alternate_font; /* Font for alternate function labels. */
 XFontStruct *h_large_font; /* Font for numeric keys. */
 
+extern const char *s_normal_fonts[];
+extern const char *s_small_fonts[];
+extern const char *s_alternate_fonts[];
+extern const char *s_large_fonts[];
 
+XFontStruct *h_get_font(Display *x_display, const char* s_fonts[]);

--- a/src/x11-calc-label.c
+++ b/src/x11-calc-label.c
@@ -24,6 +24,7 @@
  * 10 Feb 22         - Added background shading and horizontal line - MT
  * 12 Mar 22         - Implemented a state property allowing the appearance
  *                     of the label to be changed (hidden, or no line) - MT
+ * 24 Feb 24         - Do not need to include "x11-font.h" - MT
  *
  * TO DO:            - Implement ability to align text in a label using the
  *                     style property to modify the position and appearance
@@ -43,7 +44,6 @@
 #include <X11/Xlib.h>  /* XOpenDisplay(), etc. */
 #include <X11/Xutil.h> /* XSizeHints etc. */
 
-#include "x11-calc-font.h"
 #include "x11-calc-label.h"
 #include "x11-calc-switch.h"
 #include "x11-calc-button.h"

--- a/src/x11-calc-switch.c
+++ b/src/x11-calc-switch.c
@@ -26,7 +26,8 @@
  *                     switch - MT
  * 22 Oct 23         - Added method to update state when clicked - MT
  * 23 Oct 23         - Added code to draw three position switches - MT
- *
+ * 24 Feb 24         - Do not need to include "x11-font.h" - MT
+  *
  */
 
 #define NAME           "x11-calc-switch"
@@ -41,7 +42,6 @@
 #include <X11/Xlib.h>  /* XOpenDisplay(), etc. */
 #include <X11/Xutil.h> /* XSizeHints etc. */
 
-#include "x11-calc-font.h"
 #include "x11-calc-label.h"
 #include "x11-calc-switch.h"
 #include "x11-calc-button.h"

--- a/src/x11-calc.c
+++ b/src/x11-calc.c
@@ -248,6 +248,10 @@
  *                     if the file is a directory or a file! - MT
  *                   - Closes ROM file after reading - MT
  * 23 Feb 24         - Fixed bug in read_rom() - MT
+ * 24 Feb 24         - Defined an array of alternative fonts for each style
+ *                     of  text required and select the most suitable fonts
+ *                     from these alternatives to reduce the dependancy  on
+ *                     a single set of fonts - MT
  *
  * To Do             - Parse command line in a separate routine.
  *                   - Add verbose option.
@@ -259,7 +263,7 @@
 
 #define NAME           "x11-calc"
 #define VERSION        "0.12"
-#define BUILD          "0123"
+#define BUILD          "0124"
 #define DATE           "23 Feb 24"
 #define AUTHOR         "MT"
 
@@ -357,8 +361,6 @@ int main(int argc, char *argv[])
    oprocessor *h_processor;
 
    char *s_display_name = ""; /* Just use the default display */
-   char *s_font; /* Font description */
-
    char *s_title = TITLE; /* Windows title */
    char *s_pathname = NULL;
 
@@ -621,14 +623,10 @@ int main(int argc, char *argv[])
 
    XDefineCursor(x_display, x_application_window, x_cursor); /* Define the desired X cursor */
 
-   s_font = NORMAL_TEXT; /* Normal text font */
-   if (!(h_normal_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
-   s_font = SMALL_TEXT; /* Small text font */
-   if (!(h_small_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
-   s_font = ALTERNATE_TEXT; /* Alternate text font */
-   if (!(h_alternate_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
-   s_font = LARGE_TEXT; /* Large text font */
-   if (!(h_large_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
+   if (!(h_normal_font = h_get_font(x_display, s_normal_fonts))) v_error(h_err_font, s_normal_fonts[0]);
+   if (!(h_small_font = h_get_font(x_display, s_small_fonts))) v_error(h_err_font, s_small_fonts[0]);
+   if (!(h_alternate_font = h_get_font(x_display, s_alternate_fonts))) v_error(h_err_font, s_alternate_fonts[0]);
+   if (!(h_large_font = h_get_font(x_display, s_large_fonts))) v_error(h_err_font, s_large_fonts[0]);
 
    v_init_buttons(h_button); /* Create buttons */
 

--- a/src/x11-calc.c
+++ b/src/x11-calc.c
@@ -247,6 +247,7 @@
  * 19 Feb 24         - Check that stat() was successful before checking the
  *                     if the file is a directory or a file! - MT
  *                   - Closes ROM file after reading - MT
+ * 23 Feb 24         - Fixed bug in read_rom() - MT
  *
  * To Do             - Parse command line in a separate routine.
  *                   - Add verbose option.
@@ -257,9 +258,9 @@
  */
 
 #define NAME           "x11-calc"
-#define VERSION        "0.11"
-#define BUILD          "0122"
-#define DATE           "19 Feb 24"
+#define VERSION        "0.12"
+#define BUILD          "0123"
+#define DATE           "23 Feb 24"
 #define AUTHOR         "MT"
 
 #define INTERVAL 25    /* Number of ticks to execute before updating the display */
@@ -622,13 +623,10 @@ int main(int argc, char *argv[])
 
    s_font = NORMAL_TEXT; /* Normal text font */
    if (!(h_normal_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
-
    s_font = SMALL_TEXT; /* Small text font */
    if (!(h_small_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
-
    s_font = ALTERNATE_TEXT; /* Alternate text font */
    if (!(h_alternate_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
-
    s_font = LARGE_TEXT; /* Large text font */
    if (!(h_large_font = XLoadQueryFont(x_display, s_font))) v_error(h_err_font, s_font);
 


### PR DESCRIPTION
- Defined an array of alternative fonts for each style of text required and select the most suitable fonts from these alternatives to reduce the dependency on a single set of fonts.  
  If the x11 base fonts are not available then fall back to helvetica or courier fonts.
- Do not include 'x11-font.h' unless it is needed
- Fixed bug in read_rom()