### PR TITLE
make.sh/zenity install/_model fix

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -20,5 +20,5 @@
 #  28 Feb 24         - Initial version - MT
 #  29 Feb 24         - If it exists copy ./src/x11-calc.sh to ./bin - MT
 #
-[ -f ./src/x11-calc.sh ] && cp -v ./src/x11-calc.sh ./bin/ >/dev/null 2>&1
 make -s -f makefile.$(uname | tr '[:upper:]' '[:lower:]') "$@"
+[ -f ./src/x11-calc.sh ] && cp -v ./src/x11-calc.sh ./bin/

--- a/src/x11-calc.sh
+++ b/src/x11-calc.sh
@@ -197,6 +197,7 @@ fi
 command -v zenity >/dev/null 2>&1
 has_zenity=$?
 _has_zenity() { return "$has_zenity"; }
+if ! _has_zenity; then echo "\nYou may install zenity to leverage graphical interface.\n"; fi
 
 if [ ! -f "$_f_conf" ]
 then

--- a/src/x11-calc.sh
+++ b/src/x11-calc.sh
@@ -73,7 +73,7 @@ _launch() {
 
    if [ -z "$MODEL" ]; then exit 0; fi
 
-   _model="/x11-calc-`echo $MODEL | sed 's/^hp//'`"
+   _model="`echo $MODEL | sed 's/^hp//'`"
 
    case $MODEL in
       hp10c|hp11c|hp12c|hp15c|hp16c)
@@ -85,6 +85,7 @@ _launch() {
 
    [ -n "$CMD_OPTS" ] && OPTIONS="$CMD_OPTS" # Allow command line to override options
 
+   _model="/x11-calc-$_model"
    echo "`basename $0`: Executing '`dirname "$0"`"$_model `_expand_paths $OPTIONS`"'"
 
    "`dirname "$0"`"$_model `_expand_paths $OPTIONS` # Assume script is in the same directory as the executable files


### PR DESCRIPTION
- launcher: add install recommendation message if zenity is not available
- fix make.sh to always complete (and report) script copy
- fix `_model` variable definition before cmd invocation