### PR TITLE
improve models spotting in cmdline

### DIFF
--- a/makefile.linux
+++ b/makefile.linux
@@ -94,7 +94,7 @@ spice: clean $(SPICE) $(OTHERS)
 voyager: clean $(VOYAGER) $(OTHERS)
 
 define prog_template =
-hp$(1): $(1) $(TARGET)
+hp$(1): $(1)
 $(1): $(SOURCES) $(TARGET)
 	@$$(MAKE) MODEL=$(1) TARGET=../$(TARGET)
 endef

--- a/src/x11-calc.in
+++ b/src/x11-calc.in
@@ -81,7 +81,7 @@ _launch() {
 
    _model="`echo $MODEL | sed 's/^hp//'`"
 
-   if echo "$MODEL" | grep -qE "$_voyager"
+   if echo "$MODEL" | grep -qwE "$_voyager"
    then
       # if OPTIONS does not point to a rom file, set expected option to default location
       # no need to check file existence: app will error-out with proper message if missing
@@ -262,9 +262,10 @@ if [ -z "$MODEL" ]; then
    echo "`basename $0`: Model not defined - configure using '$0 --setup'"
 fi
 
-if $(echo "$1" | grep -qE "$_models") || $(echo "hp$1" | grep -qE "$_models")
+if echo "$1" | grep -qwE "$_models" || echo "hp$1" | grep -qwE "$_models"
 then
    MODEL="$1"
+   echo "$MODEL" | grep -qwE "$_models" || MODEL="hp$MODEL"
    shift
    CMD_OPTS="$*"
    _launch


### PR DESCRIPTION
- spot whole word (more robust)
- fixes issue in voyager case for alternate model naming (default rom path)
- remove one redundant dep in makefile