### PR TITLE
.desktop: add help in quick menu

### DIFF
--- a/src/x11-calc.desktop.in
+++ b/src/x11-calc.desktop.in
@@ -6,8 +6,12 @@ Exec=x11-calc.sh
 Type=Application
 Icon=x11-calc
 Categories=Utility
-Actions=Setup
+Actions=Setup;Help
 
 [Desktop Action Setup]
 Name=Set default calculator
 Exec=x11-calc.sh --setup
+
+[Desktop Action Help]
+Name=Options info
+Exec=x11-calc.sh --help


### PR DESCRIPTION
end-user may see value in using this shortcut to figure-out proper options for setup menu, without going through terminal cmdline.