### PR TITLE
cleanup (voyager/makefile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ ROM Size : 4096 words
 On Linux systems after the compilation is complete you can use the makefile
 to install the emulator locally.
 
-By default the installer will use the`$HOME/.local` if it exists, but it is
+By default the installer will use `$HOME/.local` if it exists, but it is
 possible to specify another directory by setting the directory `prefix`.
 
 ```
@@ -138,7 +138,12 @@ $ make install
 
 OR
 
-$ make install prefix='/usr'
+$ make install prefix=/usr
+```
+
+Installer also supports staged installs in a custom directory set by DESTDIR
+```
+make DESTDIR=/tmp/staging install
 ```
 
 ### Using Flatpak
@@ -275,8 +280,6 @@ When in trace mode a jump to the same instruction produces no output.
 
 
 ### ROM Images
-
-No ROM images are included for the HP10C, HP11C, HP12C, HP15C, and HP16C.
 
 The '-r <filename>' command line option provides the ability to use the ROM
 contents held in an separate file.

--- a/makefile.linux
+++ b/makefile.linux
@@ -127,21 +127,19 @@ launcher: $(SRC)/x11-calc.sh.in $(BIN)
 	@install -m755 $(SRC)/x11-calc.sh.in $(BIN)/x11-calc.sh && (cd $(BIN) && ls --color x11-calc.sh)
 
 install: $(SRC)/x11-calc.desktop.in $(SRC)/x11-calc.svg $(PRG) $(BIN)
-	@test -d $(prefix) || echo "'$(prefix)' does not exist."
-	@test -d $(prefix)
-	@install -d $(DESTDIR)$(prefix)
-	@cp -a $(BIN) $(DESTDIR)$(prefix)/ # Fail early if source and destination directories are the same
-	@install -d $(DESTDIR)$(prefix)/share/applications # Create directory
-	@install -Dm644 $(SRC)/x11-calc.desktop.in $(DESTDIR)$(prefix)/share/applications/x11-calc.desktop
+	@[ -n "$(DESTDIR)" ] || [ -d "$(prefix)" ] || \
+		{ echo "Please ensure $(prefix) path exists or set DESTDIR for staged install." >&2; exit 1; }
+	@install -d "$(DESTDIR)$(prefix)"
+	@cp -a $(BIN) "$(DESTDIR)$(prefix)"/ # Fail early if source and destination directories are the same
+	@install -Dm644 $(SRC)/x11-calc.desktop.in "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop
 	@for _item in $(MENU_LIST); do \
 		printf "\n[Desktop Action hp$$_item]\nName=• hp$$_item\nExec=x11-calc.sh hp$$_item\n" >> \
-			$(DESTDIR)$(prefix)/share/applications/x11-calc.desktop; \
-		sed -i "s/^Actions=.*/&;hp$$_item/" $(DESTDIR)$(prefix)/share/applications/x11-calc.desktop; \
+			"$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop; \
+		sed -i "s/^Actions=.*/&;hp$$_item/" "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop; \
 	done
-	@install -Dm644 $(SRC)/x11-calc.svg $(DESTDIR)$(prefix)/share/icons/hicolor/scalable/apps/x11-calc.svg
-	@install -d $(DESTDIR)$(prefix)/share/x11-calc
-	@cp -a $(PRG) $(DESTDIR)$(prefix)/share/x11-calc/
-#	-@cp -a $(BIN) $(DESTDIR)$(prefix)
+	@install -Dm644 $(SRC)/x11-calc.svg "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
+	@install -d "$(DESTDIR)$(prefix)"/share/x11-calc
+	@cp -a $(PRG) "$(DESTDIR)$(prefix)"/share/x11-calc/
 
 $(BIN):
 	@install -d $(BIN)

--- a/src/x11-calc.sh.in
+++ b/src/x11-calc.sh.in
@@ -59,6 +59,7 @@
 #                      behaviour with makefile) - MT
 #  16 Mar 24         - Better -r option handling & give error clue - macmpi
 #  18 Mar 24         - No need to load ROM for voyager models - MT
+#  19 Mar 24         - Dynamically split models list in conf file -- macmpi
 #
 
 SUCCESS=0
@@ -81,21 +82,9 @@ _launch() {
 
    if [ -z "$MODEL" ]; then exit 0; fi
 
-   _model="`echo $MODEL | sed 's/^hp//'`"
-
    [ -n "$CMD_OPTS" ] && OPTIONS="$CMD_OPTS" # Allow command line to override options
 
-   # if echo "$MODEL" | grep -qwE "$_voyager"
-   # then
-   #    # If OPTIONS does not contain a rom file option, set expected option to default path
-   #    # No need to check file existence: core_app does its own error checking
-   #    if echo "$OPTIONS" | grep -qv "\-r .*"
-   #    then
-   #       OPTIONS="$OPTIONS -r ${_data_path}x11-calc-${_model}.rom"
-   #    fi
-   # fi
-
-   _core_app="/x11-calc-$_model"
+   _core_app="/x11-calc-$MODEL"
    echo "`basename $0`: Executing '`dirname "$0"`"$_core_app $OPTIONS"'."
 
    if [ -f "`dirname "$0"`"$_core_app ]; then
@@ -216,9 +205,6 @@ _setup() {
 if [ -d "$XDG_DATA_HOME" ] # Does XDG_DATA_HOME exist
 then
    mkdir -p "${XDG_DATA_HOME}/x11-calc" # If it does create the application data directory
-   _data_path="$XDG_DATA_HOME/x11-calc/"
-else
-   _data_path="$HOME/."
 fi
 
 if [ -d "$XDG_CONFIG_HOME" ] # Does XDG_CONFIG_HOME exist
@@ -235,19 +221,16 @@ _has_zenity() { return "$has_zenity"; }
 
 if [ ! -f "$_f_conf" ]
 then
-   if ! _has_zenity; then echo "\n`basename $0`: Did you know that installing 'zenity' will give you a graphical setup interface.\n"; fi
+   ! _has_zenity && echo "\n`basename $0`: Did you know that installing 'zenity' will give you a graphical setup interface?\n"
    mkdir -p "`dirname "${_f_conf}"`"
    cat <<-EOF >"$_f_conf"
 #
 # Select which emulator to run by setting the MODEL to one
 # of the following:
 #
-# classic: $_classic
-# woodstock: $_woodstock
-# topcat: $_topcat
-# spice: $_spice
-# voyager: $_voyager
-#
+EOF
+   echo "$_models" | sed 's/\(\([^|]*|\)\{8\}\)/\1\n/g' | sed 's/^/# /' >>"$_f_conf"
+   cat <<-EOF >>"$_f_conf"
 
 MODEL=""
 OPTIONS=""
@@ -265,6 +248,7 @@ fi
 echo "`basename $0`: Using '$_f_conf'"
 
 . "$_f_conf"
+MODEL="`echo "$MODEL" | sed 's/^hp//'`"
 
 if [ -z "$MODEL" ]; then
    echo "`basename $0`: Model not defined - configure using '$0 --setup'"
@@ -272,8 +256,7 @@ fi
 
 if echo "$1" | grep -qwE "$_models" || echo "hp$1" | grep -qwE "$_models"
 then
-   MODEL="$1"
-   echo "$MODEL" | grep -qwE "$_models" || MODEL="hp$MODEL"
+   MODEL="`echo "$1" | sed 's/^hp//'`"
    shift
    CMD_OPTS="$*"
    _launch


### PR DESCRIPTION
- launcher: remove unused code/variable & dynamically split models list in conf file comments
- makefile: let `/usr` be default prefix (more universal) and only check `prefix` dir existence if not doing staged install (`DESTDIR` not set).
- README: remove voyager roms statement & adjust `prefix` and `DESTDIR` info