### PR TITLE
makefile.linux: various fixes

### DIFF
--- a/makefile.linux
+++ b/makefile.linux
@@ -63,6 +63,7 @@
 #                      and use same naming as in oyher makefiles - macmpi
 #                    - Clean out unwanted files before taking a backup, and
 #                      remove symbolic links too - MT
+#  23 Mar 24         - Use .DEFAULT target + improve x11-calc deps - macmpi
 #
 
 PROGRAM		=  x11-calc
@@ -108,35 +109,29 @@ TOPCAT		=  hp67
 SPICE		=  hp31e hp32e hp33e hp33c hp34c hp37e hp38e hp38c
 VOYAGER		=  hp10c hp11c hp12c hp15c hp16c
 MODELS		=  $(CLASSIC) $(WOODSTOCK) $(TOPCAT) $(SPICE) $(VOYAGER)
-OTHERS		=  x11-calc
+OTHERS		=  $(BIN)/x11-calc
 
 
 .PHONY: clean
 
-all: clean $(MODELS) $(OTHERS)
-	@:
+all: $(MODELS) $(OTHERS)
 
-classic: clean $(CLASSIC) $(OTHERS)
-	@:
+classic: $(CLASSIC) $(OTHERS)
 
-woodstock: clean $(WOODSTOCK) $(OTHERS)
-	@:
+woodstock: $(WOODSTOCK) $(OTHERS)
 
-topcat: clean $(TOPCAT) $(OTHERS)
-	@:
+topcat: $(TOPCAT) $(OTHERS)
 
-spice: clean $(SPICE) $(OTHERS)
-	@:
+spice: $(SPICE) $(OTHERS)
 
-voyager: clean $(VOYAGER) $(OTHERS)
-	@:
+voyager: $(VOYAGER) $(OTHERS)
 
 # this is base model target:
-%:
+.DEFAULT:
 	@$(MAKE) MODEL=$(patsubst hp%,%,$@)
 
-x11-calc: $(SRC)/x11-calc.in | $(BIN)
-	@install -m755 $(SRC)/x11-calc.in $(BIN)/x11-calc && (cd $(BIN) && ls --color x11-calc)
+$(BIN)/x11-calc: $(SRC)/x11-calc.in
+	@install -Dm755 $< $@ && (cd $(BIN) && ls --color x11-calc)
 
 install: $(SRC)/x11-calc.desktop.in $(SRC)/x11-calc.svg $(PRG) | $(BIN)
 	@[ -n "$(DESTDIR)" ] || [ -d "$(prefix)" ] || \


### PR DESCRIPTION
- remove clean target from all, etc..
- use .DEFAULT target (hence can remove NOP recipes in all,etc)
- proper x11-calc build depends