### PR TITLE
makefile.linux: various fixes

### DIFF
--- a/makefile.linux
+++ b/makefile.linux
@@ -160,8 +160,7 @@ $(BIN):
 clean:
 	@find $(SRC)/ -type l -delete
 	@rm  -f $(SRC)/*.o
-	@find $(BIN) -type f -name "$(PROGRAM)*" ! -name "*.*" \( -perm -u=x -o -perm -g=x -o -perm -o=x \) -delete  2> /dev/null || true # Delete all execuitable files
-	@rmdir $(BIN) 2> /dev/null || true
+	-@[ -d "$(BIN)" ] && rm -rf $(BIN)
 
 backup: $(FILES)
 	@echo "$(PROGRAM)-`date +'%Y%m%d%H%M'`.tar.gz"; tar -czpf ..\/$(PROGRAM)-`date +'%Y%m%d%H%M'`.tar.gz $(FILES)

--- a/makefile.linux
+++ b/makefile.linux
@@ -69,6 +69,7 @@
 #                    - Do not clean up files before backing up - MT
 #                    - Make clean deletes execuitables (leaving other files
 #                      in the same folder untouched) - MT
+#                      Use .DEFAULT target + improve x11-calc deps - macmpi
 #
 
 PROGRAM		=  x11-calc
@@ -114,35 +115,29 @@ TOPCAT		=  hp67
 SPICE		=  hp31e hp32e hp33e hp33c hp34c hp37e hp38e hp38c
 VOYAGER		=  hp10c hp11c hp12c hp15c hp16c
 MODELS		=  $(CLASSIC) $(WOODSTOCK) $(TOPCAT) $(SPICE) $(VOYAGER)
-OTHERS		=  x11-calc
+OTHERS		=  $(BIN)/x11-calc
 
 
 .PHONY: clean
 
 all: $(MODELS) $(OTHERS)
-	@:
 
 classic: $(CLASSIC) $(OTHERS)
-	@:
 
 woodstock: $(WOODSTOCK) $(OTHERS)
-	@:
 
 topcat: clean $(TOPCAT) $(OTHERS)
-	@:
 
 spice: $(SPICE) $(OTHERS)
-	@:
 
 voyager: $(VOYAGER) $(OTHERS)
-	@:
 
 # this is base model target:
-%:
+.DEFAULT:
 	@$(MAKE) MODEL=$(patsubst hp%,%,$@)
 
-x11-calc: $(SRC)/x11-calc.in | $(BIN)
-	@install -m755 $(SRC)/x11-calc.in $(BIN)/x11-calc && (cd $(BIN) && ls --color x11-calc)
+$(BIN)/x11-calc: $(SRC)/x11-calc.in
+	@install -Dm755 $< $@ && (cd $(BIN) && ls --color x11-calc)
 
 install: $(SRC)/x11-calc.desktop.in $(SRC)/x11-calc.svg $(PRG) | $(BIN)
 	@[ -n "$(DESTDIR)" ] || [ -d "$(prefix)" ] || \

--- a/src/makefile.linux
+++ b/src/makefile.linux
@@ -116,6 +116,8 @@ ifneq ($(SCALE_HEIGHT),)
 FLAGS		+= -D SCALE_HEIGHT=$(SCALE_HEIGHT)
 endif
 
+all: $(BIN)/$(PROGRAM)-$(MODEL)
+
 $(BIN)/$(PROGRAM)-$(MODEL): $(OBJECTS) | $(BIN)
 ifdef VERBOSE
 	@echo
@@ -145,8 +147,6 @@ $(SOURCES) :
 		_ref="`echo "$@" | sed 's/_$(MODEL)//'`"; \
 		ln -s "$$_ref" "$@" ; \
 	fi
-
-all: $(BIN)/$(PROGRAM)-$(MODEL)
 
 clean: | $(BIN)
 	@find . -type l -delete


### PR DESCRIPTION
- remove clean target from all, etc..
- use .DEFAULT target (hence can remove NOP recipes in all,etc)
- proper x11-calc build depends
- clean overall bin dir
- src/makefile.linux: put back all target at top