### PR TITLE
top makefiles: use common for Linux/NetBSD/Darwin

### DIFF
--- a/makefile
+++ b/makefile
@@ -25,8 +25,18 @@
 #
 
 all:
-	@$(MAKE) -s -f "makefile.`uname | tr '[:upper:]' '[:lower:]'`" $@
+	@_flavor="`uname | tr '[:upper:]' '[:lower:]'`"; \
+	if [ "$$_flavor" = "osf1" ]; then \
+		$(MAKE) -s -f "makefile.osf1" $@ ; \
+	else \
+		$(MAKE) -s -f "makefile.common" $@ ; \
+	fi
 
 .DEFAULT:
-	@$(MAKE) -s -f "makefile.`uname | tr '[:upper:]' '[:lower:]'`" $@
+	@_flavor="`uname | tr '[:upper:]' '[:lower:]'`"; \
+	if [ "$$_flavor" = "osf1" ]; then \
+		$(MAKE) -s -f "makefile.osf1" $@ ; \
+	else \
+		$(MAKE) -s -f "makefile.common" $@ ; \
+	fi
 

--- a/makefile.common
+++ b/makefile.common
@@ -73,6 +73,7 @@
 #                    - Feed x11-calc _models with makefile  MODELS - macmpi
 #  24 Mar 24         - Updated FILES - MT
 #  28 Mar 24         - Leverage src/makefile.generic - macmpi
+#  30 Mar 24         - Now common makefile for Linux/NetBSD/Darwin - macmpi
 #
 
 PROGRAM		=  x11-calc
@@ -83,8 +84,8 @@ PRG		:= prg
 ROM		:= rom
 IMG		:= img
 
-DESTDIR		?=
-prefix		?= $$HOME/.local
+DESTDIR		=
+prefix		= $$HOME/.local
 
 FILES		=  $(wildcard $(SRC)/*.c) $(wildcard $(SRC)/*.h) $(wildcard $(SRC)/*.in)
 FILES		+= $(wildcard $(SRC)/*.c.[0-9]) $(wildcard $(SRC)/*.h.[0-9])  $(wildcard $(SRC)/*.in.[0-9])
@@ -106,7 +107,7 @@ FILES		+= $(wildcard $(IMG)/x11-calc*.png) $(wildcard $(IMG)/x11-calc*.png.[0-9]
 FILES		+= $(wildcard *.md) $(wildcard *.md.[0-9]) LICENSE
 FILES		+= .gitignore .gitattributes
 
-SUBMAKE		=  --no-print-directory -C ./src -f makefile.linux
+SUBMAKE		=  -C ./src -f makefile
 
 LIST		=  hp35 hp21 hp25c hp29c hp31e hp32e hp33c hp34c hp10c hp11c hp12c hp15c hp16c
 
@@ -116,7 +117,7 @@ TOPCAT		=  hp67
 SPICE		=  hp31e hp32e hp33e hp33c hp34c hp37e hp38e hp38c
 VOYAGER		=  hp10c hp11c hp12c hp15c hp16c
 MODELS		=  $(CLASSIC) $(WOODSTOCK) $(TOPCAT) $(SPICE) $(VOYAGER)
-OTHERS		=  $(BIN)/x11-calc
+OTHERS		=  x11-calc
 
 
 .PHONY: clean
@@ -135,31 +136,40 @@ voyager: $(VOYAGER) $(OTHERS)
 
 # this is base model target:
 .DEFAULT:
-	@$(MAKE) $(SUBMAKE) MODEL=$(patsubst hp%,%,$@)
+	@$(MAKE) $(SUBMAKE) MODEL=${@:hp%=%} all
+
+x11-calc: $(BIN)/x11-calc
 
 $(BIN)/x11-calc: $(SRC)/x11-calc.in
-	@install -Dm755 $< $@
+	@mkdir -p $(BIN)
+	@cp -a $(SRC)/x11-calc.in $(BIN)/x11-calc
+	@chmod +x $(BIN)/x11-calc
 	@_mdls="$$(echo "$(MODELS)" | tr ' ' '|')"; \
-		sed -i "s/^_models=\".*/_models=\"$$_mdls\"/" $@
-	@(cd $(BIN) && ls --color x11-calc)
+		sed -i "s/^_models=\".*/_models=\"$$_mdls\"/" $(BIN)/x11-calc
+	@(cd $(BIN) && ls x11-calc)
 
-install: $(SRC)/x11-calc.desktop.in $(SRC)/x11-calc.svg $(PRG) | $(BIN)
+install: $(SRC)/x11-calc.desktop.in $(SRC)/x11-calc.svg $(PRG)
 	@[ -n "$(DESTDIR)" ] || [ -d "$(prefix)" ] || \
 		{ echo "Please ensure $(prefix) path exists or set DESTDIR for staged install." >&2; exit 1; }
-	@install -d "$(DESTDIR)$(prefix)"
+	@mkdir -p "$(DESTDIR)$(prefix)"
 	@cp -a $(BIN) "$(DESTDIR)$(prefix)"/ # Fail early if source and destination directories are the same
-	@install -Dm644 $(SRC)/x11-calc.desktop.in "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop
+# .desktop file
+	@mkdir -p "$(DESTDIR)$(prefix)"/share/applications
+	@cp -a $(SRC)/x11-calc.desktop.in "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop
+	@chmod 644 "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop
 	@for _item in $(LIST); do \
 		printf "\n[Desktop Action $$_item]\nName=• $$_item\nExec=x11-calc $$_item\n" >> \
 			"$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop; \
 		sed -i "s/^Actions=.*/&;$$_item/" "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop; \
 	done
-	@install -Dm644 $(SRC)/x11-calc.svg "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
-	@install -d "$(DESTDIR)$(prefix)"/share/x11-calc
+# icon file
+	@mkdir -p "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps
+	@cp $(SRC)/x11-calc.svg "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
+	@chmod 644 "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
+# prg folder
+	@mkdir -p "$(DESTDIR)$(prefix)"/share/x11-calc/
 	@cp -a $(PRG) "$(DESTDIR)$(prefix)"/share/x11-calc/
-
-$(BIN):
-	@install -d $(BIN)
+	@chmod -R 644 "$(DESTDIR)$(prefix)"/share/x11-calc/prg/*
 
 clean:
 	@find $(SRC)/ -type l -delete

--- a/src/makefile
+++ b/src/makefile
@@ -31,10 +31,10 @@ MODEL	=  21
 all:
 	@_flavor="`uname -s | tr '[:upper:]' '[:lower:]'`"; \
 	echo "$$_flavor" | grep -qwE "netbsd|darwin" && _flavor=bsd; \
-	$(MAKE) -s -f "makefile.$$_flavor" MODEL=$(MODEL) $@
+	$(MAKE) -f "makefile.$$_flavor" MODEL=$(MODEL) $@
 
-.DEFAULT:
+clean:
 	@_flavor="`uname -s | tr '[:upper:]' '[:lower:]'`"; \
 	echo "$$_flavor" | grep -qwE "netbsd|darwin" && _flavor=bsd; \
-	$(MAKE) -s -f "makefile.$$_flavor" MODEL=$(MODEL) $@
+	$(MAKE) -f "makefile.$$_flavor" MODEL=$(MODEL) $@
 

--- a/src/makefile.bsd
+++ b/src/makefile.bsd
@@ -48,4 +48,4 @@ CFLAGS	+= -I /opt/X11/include/X11/
 LDFLAGS += -L /opt/X11/lib/
 .endif
 
-include makefile.generic
+include makefile.common

--- a/src/makefile.common
+++ b/src/makefile.common
@@ -27,16 +27,16 @@
 #  28 Mar 24         - Initial version - macmpi
 #
 
-MODEL	?=  21
+MODEL	=  21
 PROGRAM	:=  x11-calc-$(MODEL)
-BIN		?= ../bin
+BIN		= ../bin
 
 # SHARED sources are model-dependant via HP$(MODEL) #define statements
 SHARED	=  x11-calc.c x11-calc-cpu.c x11-calc-display.c x11-calc-segment.c x11-calc-messages.c x11-calc-button.c x11-keyboard.c
 COMMON	=  x11-calc-switch.c x11-calc-label.c x11-calc-colour.c x11-calc-font.c gcc-wait.c gcc-exists.c
 
-CC		?= cc
-DEBUG	?=
+CC		= cc
+DEBUG	=
 
 LDLIBS	+= -lX11 -lm
 CFLAGS	+= -fcommon -Wall -pedantic -std=gnu99

--- a/src/makefile.linux
+++ b/src/makefile.linux
@@ -78,7 +78,7 @@
 #  23 Mar 25         - Instantiate without symlinks trick and use std FLAGS
 #                      to maximize use of implicit build rules - macmpi
 #                    - Remove VERBOSE in favor of make --dry-run - macmpi
-#  23 Mar 25         - Rely on makefile.generic
+#  23 Mar 25         - Rely on makefile.common
 #
 
 CFLAGS	?= -O2
@@ -99,4 +99,4 @@ ifneq ($(SCALE_HEIGHT),)
 CFLAGS		+= -D SCALE_HEIGHT=$(SCALE_HEIGHT)
 endif
 
-include makefile.generic
+include makefile.common


### PR DESCRIPTION
- makefile.common: use original linux as base, modified to call on src/makefile (which will then trigger either linux or bsd)
- makefile: adjust filter to redirect to either makefile.osf1 or makefile.common
- src/makefile: only 2 targets: all and clean
- src/makefile.common: renamed from src/makefile.generic
- src/makefile.linux/bsd: user renamed src/makefile.common