### PR TITLE
top makefiles: add desktop variants

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,14 +23,27 @@
 #                    - Fixed default rule so it works on NetBSD, Tru64, and
 #                      Linux (now we can get rid of make.sh) - MT
 #  01 Apr 24         - Consolidate Linux/NetBSD/Darwin and OSF1 - macmpi
+#  02 Apr 24         - Add differentiated desktop files installs - macmpi
 #
 
 all:
-	@$(MAKE) -s -f "makefile.common" $@ ;
-
-backup:
-	@$(MAKE) -s -f "makefile.backup" $@ ;
+	@$(MAKE) -s -f "makefile.common" $@
 
 .DEFAULT:
-	@$(MAKE) -s -f "makefile.common" $@ ;
+	@$(MAKE) -s -f "makefile.common" $@
+
+clean:
+	@$(MAKE) -s -f "makefile.common" $@
+
+install:
+	@$(MAKE) -s -f "makefile.common" $@
+	@_flavor="`uname | tr '[:upper:]' '[:lower:]'`"; \
+	if [ "$$_flavor" = "osf1" ]; then \
+		$(MAKE) -s -f "makefile.cde" desktop; \
+	else \
+		$(MAKE) -s -f "makefile.freedesktop" desktop; \
+	fi
+
+backup:
+	@$(MAKE) -s -f "makefile.backup" $@
 

--- a/makefile.backup
+++ b/makefile.backup
@@ -22,7 +22,7 @@
 #                    - Modified to work on Tru64 Linux - MT
 #
 
-include makefile.include
+include makefile.env
 
 FILES	= `ls makefile makefile.backup makefile.common makefile.*.[0-9] $(SRC)/makefile $(SRC)/makefile.common $(SRC)/makefile.linux $(SRC)/makefile.bsd $(SRC)/makefile.osf1 $(SRC)/makefile.*.[0-9] 2>/dev/null || true`
 SOURCE	= `ls $(SRC)/*.c $(SRC)/*.c.[0-9] $(SRC)/*.h $(SRC)/*.h.[0-9] $(SRC)/*.in $(SRC)/*.in.[0-9] 2>/dev/null || true`

--- a/makefile.cde
+++ b/makefile.cde
@@ -1,0 +1,48 @@
+#
+#  makefile.cde - RPN (Reverse Polish) calculator simulator.
+#
+#  Copyright(C) 2024 - macmpi - MT
+#
+#  This  program is free software: you can redistribute it and/or modify it
+#  under  the terms of the GNU General Public License as published  by  the
+#  Free  Software Foundation, either version 3 of the License, or (at  your
+#  option) any later version.
+#
+#  This  program  is distributed in the hope that it will  be  useful,  but
+#  WITHOUT   ANY   WARRANTY;   without even   the   implied   warranty   of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#  Public License for more details.
+#
+#  You  should have received a copy of the GNU General Public License along
+#  with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Note separator (tab) at the beginning of the line CANNOT be a space..!
+#
+#  02 Apr 24         - Initial version - macmpi
+#
+
+LIST	= hp35 hp21 hp25c hp29c hp31e hp32e hp33c hp34c hp10c hp11c hp12c hp15c hp16c
+
+include makefile.env
+
+desktop:
+# desktop integration files install for CDE
+# check dtcreate for desktop icon action file
+# icons in xpm format 16×16 (x11-calc.t.pm) 32×32 (x11-calc.m.pm) 48×48 (x11-calc.l.pm) in either:
+# /etc/dt/appconfig/icons/, /usr/dt/appconfig/icons/ or $HOME/.dt/icons
+	@:
+#	@mkdir -p "$(DESTDIR)$(prefix)"/share/applications;
+#	@_dest_file="$(DESTDIR)$(prefix)/share/applications/x11-calc.desktop"; \
+#	_tmp_file="`mktemp`"; \
+#	cp $(SRC)/x11-calc.desktop.in "$$_dest_file"; \
+#	for _item in $(LIST); do \
+#		printf "\n[Desktop Action $$_item]\nName=• $$_item\nExec=x11-calc $$_item\n" >> "$$_dest_file"; \
+#		sed "s/^Actions=.*/&;$$_item/" "$$_dest_file" > "$$_tmp_file" ; mv "$$_tmp_file" "$$_dest_file"; \
+#	done; \
+#	chmod 644 "$$_dest_file"; \
+#	rm -f "$$_tmp_file"
+# icon file
+#	@mkdir -p "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps
+#	@cp $(SRC)/x11-calc.svg "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
+#	@chmod 644 "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
+

--- a/makefile.common
+++ b/makefile.common
@@ -76,20 +76,11 @@
 #  30 Mar 24         - Now common makefile for Linux/NetBSD/Darwin - macmpi
 #  01 Apr 24         - Prepairation for a common makefile on osf1 - macmpi
 #                    - Tested on Tru64 UNIX and fixed up minor issues - MT
+#  02 Apr 24         - Use  env  variables  include  and  spin-off  desktop
+#                      specific files - macmpi
 #
 
-PROGRAM		=  x11-calc
-
-BIN		= bin
-SRC		= src
-PRG		= prg
-ROM		= rom
-IMG		= img
-
-DESTDIR		=
-prefix		= $$HOME/.local
-
-LIST		= hp35 hp21 hp25c hp29c hp31e hp32e hp33c hp34c hp10c hp11c hp12c hp15c hp16c
+include makefile.env
 
 CLASSIC		= hp35 hp45 hp70 hp80
 WOODSTOCK	= hp21 hp22 hp25 hp25c hp27 hp29c
@@ -124,39 +115,22 @@ x11-calc: $(BIN)/x11-calc
 
 $(BIN)/x11-calc: $(SRC)/x11-calc.in
 	@mkdir -p $(BIN)
-#	@cp $(SRC)/x11-calc.in $@
 	@_mdls=`echo "$(MODELS)" | tr ' ' '|'` ; \
-		cat $(SRC)/x11-calc.in | sed "s/^_models=\".*/_models=\"$$_mdls\"/" > $@
+		sed "s/^_models=\".*/_models=\"$$_mdls\"/" $(SRC)/x11-calc.in > $@
 	@chmod +x $@
 	@ls $@ | sed "s:$(BIN)/::g"
+
+clean:
+	@rm -f $(SRC)/*.o $(SRC)/*.o_*
+	-@[ -d "$(BIN)" ] && rm -rf $(BIN)
 
 install: $(SRC)/x11-calc.desktop.in $(SRC)/x11-calc.svg $(PRG)
 	@[ -n "$(DESTDIR)" ] || [ -d "$(prefix)" ] || \
 		{ echo "Please ensure $(prefix) path exists or set DESTDIR for staged install." >&2; exit 1; }
 	@mkdir -p "$(DESTDIR)$(prefix)"
 	@cp -R $(BIN) "$(DESTDIR)$(prefix)"/ # Fail early if source and destination directories are the same
-# .desktop file
-	@mkdir -p "$(DESTDIR)$(prefix)"/share/applications
-	@cp -R $(SRC)/x11-calc.desktop.in "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop
-	@chmod 644 "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop
-	@_flavor="`uname | tr '[:upper:]' '[:lower:]'`"; \
-	if [ "$$_flavor" != "osf1" ]; then \
-	for _item in $(LIST); do \
-		printf "\n[Desktop Action $$_item]\nName=• $$_item\nExec=x11-calc $$_item\n" >> \
-			"$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop; \
-		sed -i "s/^Actions=.*/&;$$_item/" "$(DESTDIR)$(prefix)"/share/applications/x11-calc.desktop; \
-	done; \
-	fi
-# icon file
-	@mkdir -p "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps
-	@cp $(SRC)/x11-calc.svg "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
-	@chmod 644 "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
 # prg folder
 	@mkdir -p "$(DESTDIR)$(prefix)"/share/x11-calc/
 	@cp -R $(PRG) "$(DESTDIR)$(prefix)"/share/x11-calc/
 	@chmod -R 644 "$(DESTDIR)$(prefix)"/share/x11-calc/prg/*
-
-clean:
-	@rm  -f $(SRC)/*.o $(SRC)/*.o_*
-	-@[ -d "$(BIN)" ] && rm -rf $(BIN)
 

--- a/makefile.common
+++ b/makefile.common
@@ -122,7 +122,7 @@ $(BIN)/x11-calc: $(SRC)/x11-calc.in
 
 clean:
 	@rm -f $(SRC)/*.o $(SRC)/*.o_*
-	-@[ -d "$(BIN)" ] && rm -rf $(BIN)
+	@[ -d "$(BIN)" ] && rm -rf $(BIN) || true
 
 install: $(SRC)/x11-calc.desktop.in $(SRC)/x11-calc.svg $(PRG)
 	@[ -n "$(DESTDIR)" ] || [ -d "$(prefix)" ] || \

--- a/makefile.env
+++ b/makefile.env
@@ -1,5 +1,5 @@
 #
-#  makefile.backup - RPN (Reverse Polish) calculator simulator.
+#  makefile.env - RPN (Reverse Polish) calculator simulator.
 #
 #  Copyright(C) 2024 - macmpi - MT
 #
@@ -28,3 +28,7 @@ SRC		= src
 PRG		= prg
 ROM		= rom
 IMG		= img
+
+DESTDIR		=
+prefix		= $$HOME/.local
+

--- a/makefile.freedesktop
+++ b/makefile.freedesktop
@@ -1,0 +1,45 @@
+#
+#  makefile.freedesktop - RPN (Reverse Polish) calculator simulator.
+#
+#  Copyright(C) 2024 - macmpi - MT
+#
+#  This  program is free software: you can redistribute it and/or modify it
+#  under  the terms of the GNU General Public License as published  by  the
+#  Free  Software Foundation, either version 3 of the License, or (at  your
+#  option) any later version.
+#
+#  This  program  is distributed in the hope that it will  be  useful,  but
+#  WITHOUT   ANY   WARRANTY;   without even   the   implied   warranty   of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#  Public License for more details.
+#
+#  You  should have received a copy of the GNU General Public License along
+#  with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  Note separator (tab) at the beginning of the line CANNOT be a space..!
+#
+#  02 Apr 24         - Initial version - macmpi
+#
+
+LIST	= hp35 hp21 hp25c hp29c hp31e hp32e hp33c hp34c hp10c hp11c hp12c hp15c hp16c
+
+include makefile.env
+
+desktop:
+# desktop integration files install for freedesktop compatible desktops
+# (workaround bsd sed -i syntax compatibility issues)
+	@mkdir -p "$(DESTDIR)$(prefix)"/share/applications;
+	@_dest_file="$(DESTDIR)$(prefix)/share/applications/x11-calc.desktop"; \
+	_tmp_file="`mktemp`"; \
+	cp $(SRC)/x11-calc.desktop.in "$$_dest_file"; \
+	for _item in $(LIST); do \
+		printf "\n[Desktop Action $$_item]\nName=• $$_item\nExec=x11-calc $$_item\n" >> "$$_dest_file"; \
+		sed "s/^Actions=.*/&;$$_item/" "$$_dest_file" > "$$_tmp_file" ; mv "$$_tmp_file" "$$_dest_file"; \
+	done; \
+	chmod 644 "$$_dest_file"; \
+	rm -f "$$_tmp_file"
+# icon file
+	@mkdir -p "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps
+	@cp $(SRC)/x11-calc.svg "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
+	@chmod 644 "$(DESTDIR)$(prefix)"/share/icons/hicolor/scalable/apps/x11-calc.svg
+

--- a/src/x11-calc.in
+++ b/src/x11-calc.in
@@ -74,7 +74,7 @@ ENOACC=126 # Permission denied (not official)
 ENOCMD=127 # Executable file not found (not official)
 ENOFNT=192 # No font (not official)
 
-# Prototype model list: will be filled-in by makefile
+# Prototype model list: is to be filled-in by makefile
 _models="hp34c|hp11"
 
 #- launch()
@@ -159,14 +159,16 @@ _config (){
 
    case $? in
       0)
+         _tmpfile="$(mktemp)"
          if [ "$DROPDOWN" ] # The seperator used by different forms is different!
          then
-            sed -i "s|^MODEL=.*|MODEL=\"${_selection%|*}\"|" "$_f_conf"
-            sed -i "s|^OPTIONS=.*|OPTIONS=\"${_selection#*|}\"|" "$_f_conf"
+            sed "s|^MODEL=.*|MODEL=\"${_selection%|*}\"|" "$_f_conf" > $_tmpfile
+            sed "s|^OPTIONS=.*|OPTIONS=\"${_selection#*|}\"|" $_tmpfile > "$_f_conf"
          else
-            sed -i "s|^MODEL=.*|MODEL=\"${_selection%,|*}\"|" "$_f_conf"
-            sed -i "s|^OPTIONS=.*|OPTIONS=\"${_selection#*,|}\"|" "$_f_conf"
+            sed "s|^MODEL=.*|MODEL=\"${_selection%,|*}\"|" "$_f_conf" > $_tmpfile
+            sed "s|^OPTIONS=.*|OPTIONS=\"${_selection#*,|}\"|" $_tmpfile > "$_f_conf"
          fi
+         rm -f $_tmpfile
          ;;
       1)
          exit 0 # User pressed cancel so just quit - don't attempt to launch the emulator

--- a/src/x11-calc.in
+++ b/src/x11-calc.in
@@ -230,7 +230,7 @@ then
 # of the following:
 #
 EOF
-   echo "$_models" | sed 's/\(\([^|]*|\)\{8\}\)/\1\n/g' | sed 's/^/# /' >>"$_f_conf"
+   echo "$_models" | sed 's/\(\([^|]*|\)\{8\}\)/\1*/g' | tr '*' '\n' | sed 's/^/# /' >>"$_f_conf"
    cat <<-EOF >>"$_f_conf"
 
 MODEL=""


### PR DESCRIPTION
- install has 2 phases: common and desktop-specific (freedesktop & cde)
- remove sed -i due to syntax compatibility issues between gnu/bsd