### PR TITLE
Additional defined for FreeBSD

### DIFF
--- a/src/x11-keyboard.c
+++ b/src/x11-keyboard.c
@@ -48,7 +48,7 @@
 
 #include "gcc-debug.h"
 
-#if defined(__linux__) || defined(__NetBSD__)
+#if defined(__linux__) || defined(__NetBSD__) || defined (__FreeBSD__)
 
 /* Attempts to translate a key code into a character. */
 static void v_key_decode(okeyboard *h_keyboard, Display *x_display, KeyCode x_keycode, unsigned int i_keystate) {

--- a/src/x11-keyboard.h
+++ b/src/x11-keyboard.h
@@ -25,7 +25,7 @@
  *
  */
 
-#if defined(__linux__) || defined(__NetBSD__)
+#if defined(__linux__) || defined(__NetBSD__) || defined (__FreeBSD__)
 
 typedef struct { /* Calculator button structure. */
    Display* display;


### PR DESCRIPTION
In addition to your changes for FreeBSD, there were two more places where the 'defined'-clause should be added to make compilation work.